### PR TITLE
Fix build errors caused by an invalid docstring parameter

### DIFF
--- a/contracts/WrapAndUnWrapSushi.sol
+++ b/contracts/WrapAndUnWrapSushi.sol
@@ -863,7 +863,7 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
      * token
      * @param amount Amount of input tokens to be swapped
      * @param userSlippageTolerance Maximum permissible slippage tolerance
-     * @return amounts_ The input token amount and all subsequent output token 
+     * @return amounts1 The input token amount and all subsequent output token 
      * amounts
      */
     function conductUniswapT4T(


### PR DESCRIPTION
Modify the Natspec docstring return parameter in the Sushi wrapper contract `WrapAndUnWrapSushi.sol` to fix intermittent build errors