### PR TITLE
Add Natspec style comments to key contracts

### DIFF
--- a/contracts/PlexusOracle.sol
+++ b/contracts/PlexusOracle.sol
@@ -1,15 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/**
-_____  _
-|  __ \| |
-| |__) | | _____  ___   _ ___
-|  ___/| |/ _ \ \/ / | | / __|
-| |    | |  __/>  <| |_| \__ \
-|_|   _|_|\___/_/\_\\__,_|___/ 
- *Submitted for verification at Etherscan.io on 2020-12-11
-*/
-
 pragma solidity >=0.8.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
@@ -22,10 +11,13 @@ import "./interfaces/uniswap/IUniswapV2RouterLite.sol";
 import "./interfaces/staking/ITokenRewards.sol";
 import "./interfaces/ITVLOracle.sol";
 
+/// @title Plexus Oracle Contract
+/// @author Team Plexus
 contract PlexusOracle is OwnableUpgradeable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
+    // Oracle state variables
     string[] public farmTokenPlusFarmNames;
     address[] public farmAddresses;
     address[] public farmTokens;
@@ -46,18 +38,36 @@ contract PlexusOracle is OwnableUpgradeable {
     constructor() payable {
     }
 
+    /**
+     * @notice Executed on a call to the contract if none of the other 
+     * functions match the given function signature, or if no data was 
+     * supplied at all and there is no receive Ether function
+     */
     fallback() external payable {
     }
 
+    /**
+     * @notice Function executed on plain ether transfers and on a call to the 
+     * contract with empty calldata 
+     */
     receive() external payable {
     }
 
+    /**
+     * @notice Initialize the core contract 
+     * @param _uniswap Address to the Uniswap V2 router contract 
+     * @param _usdc Address to the USDC token contract
+     */
     function initialize(address _uniswap, address _usdc) external initializeOnceOnly {
         uniswapAddress = _uniswap;
         uniswap = IUniswapV2RouterLite(uniswapAddress);
         usdcCoinAddress = _usdc;
     }
 
+    /**
+     * @notice Allow contract owner to update the address to the TVL oracle
+     * contract
+     * @param theAddress Address to the updated TVL Oracle contract */
     function updateTVLAddress(address theAddress) external onlyOwner returns (bool) {
         tvlOracleAddress = theAddress;
         tvlOracle = ITVLOracle(theAddress);
@@ -65,6 +75,10 @@ contract PlexusOracle is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Allow contract owner to update the address to the Price oracle
+     * contract
+     * @param theAddress Address to the updated Price Oracle contract */
     function updatePriceOracleAddress(address theAddress) external onlyOwner returns (bool) {
         uniswapAddress = theAddress;
         uniswap = IUniswapV2RouterLite(theAddress);
@@ -72,12 +86,20 @@ contract PlexusOracle is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Allow contract owner to update the address to the USDC token
+     * contract
+     * @param theAddress Address to the updated USDC token contract */
     function updateUSD(address theAddress) external onlyOwner returns (bool) {
         usdcCoinAddress = theAddress;
         updateDirectory("USD", theAddress);
         return true;
     }
 
+    /**
+     * @notice Allow contract owner to update the address to the token rewards
+     * contract
+     * @param theAddress Address to the updated token rewards contract */
     function updateRewardAddress(address theAddress) external onlyOwner returns (bool) {
         rewardAddress = theAddress;
         reward = ITokenRewards(theAddress);
@@ -85,18 +107,33 @@ contract PlexusOracle is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Allow contract owner to update the address to the Plexus core
+     * contract
+     * @param theAddress Address to the updated Plexus core contract */
     function updateCoreAddress(address theAddress) external onlyOwner returns (bool) {
         coreAddress = theAddress;
         updateDirectory("CORE", theAddress);
         return true;
     }
 
+    /**
+     * @notice Allow contract owner to update the address to the Tier 1
+     * controller contract
+     * @param theAddress Address to the updated Tier 1 controller contract */
     function updateTier1Address(address theAddress) external onlyOwner returns (bool) {
         tier1Address = theAddress;
         updateDirectory("TIER1", theAddress);
         return true;
     }
 
+    /** 
+     * @notice Add farming platform details to the oracle contract registries 
+     * @param name Farm platform name
+     * @param farmAddress Address to the farming contract
+     * @param farmToken Address to the token contract deposited in the farm
+     * @param platformAddress Address to the farm platform contract
+     */
     function setPlatformContract(
         string memory name,
         address farmAddress,
@@ -113,6 +150,9 @@ contract PlexusOracle is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Bulk modify all farming platform details
+     * @param theNames Array of names to the updated farming platforms */
     function replaceAllStakableDirectory(
         string[] memory theNames,
         address[] memory theFarmAddresses,
@@ -124,6 +164,15 @@ contract PlexusOracle is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Retrieve the TVL for a given token from the specified Tier 2
+     * contract
+     * @param tokenAddress Address to the given token for which the TVL is to 
+     * be retrieved 
+     * @param tier2Address Address to the Tier 2 contract to retrieve the TVL
+     * from
+     * @return TVL for the given token from the specified Tier 2 contract
+     */
     function getTotalValueLockedInternalByToken(
         address tokenAddress,
         address tier2Address
@@ -137,12 +186,28 @@ contract PlexusOracle is OwnableUpgradeable {
         return result;
     }
 
+    /**
+     * @notice Retrieve details about all tokens that can be staked 
+     * @return Two arrays - one containing a list of addresses to all tokens 
+     * that can be staked and another containing their respective token names 
+     */
     function getStakableTokens() external view returns (address[] memory, string[] memory) {
         address[] memory stakableAddrs = farmAddresses;
         string[] memory stakableNames = farmTokenPlusFarmNames;
         return (stakableAddrs, stakableNames);
     }
 
+    /**
+     * @notice Retrieve the amount of a given token staked by a particular user
+     * using a specified Tier 2 contract
+     * @param tokenAddress Address to the given token for which the staked 
+     * amount is to be retrieved
+     * @param userAddress Address to the user's wallet
+     * @param tier2Address Address to the Tier 2 contract used to stake the 
+     * specified tokens 
+     * @return Amount of specified tokens staked by the given user via the
+     * provided Tier 2 contract
+     */
     function getAmountStakedByUser(
         address tokenAddress,
         address userAddress,
@@ -152,6 +217,17 @@ contract PlexusOracle is OwnableUpgradeable {
         return exContract.getStakedPoolBalanceByUser(userAddress, tokenAddress);
     }
 
+    /**
+     * @notice Retrieve the rewards accumulated by a given user for a specified 
+     * token deposited in a particular Tier 2 contract 
+     * @param userAddress Address to the user's wallet
+     * @param tokenAddress Address to the token for which reward value is to be
+     * retrieved 
+     * @param tier2FarmAddress Address to the Tier 2 contract where the given 
+     * token was deposited
+     * @return Rewards accumulated by the given user for the particular token 
+     * from the specified Tier 2 contract address 
+     */
     function getUserCurrentReward(
         address userAddress,
         address tokenAddress,
@@ -170,6 +246,12 @@ contract PlexusOracle is OwnableUpgradeable {
         return result;
     }
 
+    /** 
+     * @notice Retrieve the current price of a token
+     * @param tokenAddress Address to the token for which the price is to be 
+     * retrieved
+     * @return Current price of the specified token 
+     */
     function getTokenPrice(address tokenAddress, uint256 amount) external view returns (uint256) {
         address[] memory addresses = new address[](2);
         addresses[0] = tokenAddress;
@@ -179,6 +261,14 @@ contract PlexusOracle is OwnableUpgradeable {
         return resultingTokens;
     }
 
+    /**
+     * @notice Retrieve the balance of a given token from a specified user
+     * wallet 
+     * @param userAddress Address to the user's wallet 
+     * @param tokenAddress Address to the token for which the balance is to be 
+     * retrieved
+     * @return Balance of the given token in the specified user wallet
+     */
     function getUserWalletBalance(
         address userAddress, 
         address tokenAddress
@@ -191,6 +281,11 @@ contract PlexusOracle is OwnableUpgradeable {
         return token.balanceOf(userAddress);
     }
 
+    /**
+     * @notice Retrieve the commission rates for a given platform
+     * @param platformContract Address to the given platform contract
+     * @return Commission rate for the given platform contract 
+     */
     function getCommissionByContract(address platformContract) external view returns (uint256) {
         IExternalPlatform exContract = IExternalPlatform(platformContract);
         return exContract.commission();
@@ -207,7 +302,17 @@ contract PlexusOracle is OwnableUpgradeable {
         IExternalPlatform exContract = IExternalPlatform(platformContract);
         return exContract.totalAmountStaked(tokenAddress);
     }
-
+    
+    /**
+     * @notice Retrieve the amount of a given token deposited by a specified 
+     * using a particular platform
+     * @param platformContract Address to the platform where the tokens were
+     * deposited
+     * @param tokenAddress Address to the contract for the deposited token
+     * @param userAddress Address to the user's wallet
+     * @return The amount of tokens deposited by the given user via the 
+     * provided platform contract
+     */
     function getAmountCurrentlyDepositedByContract(
         address platformContract,
         address tokenAddress,
@@ -221,6 +326,16 @@ contract PlexusOracle is OwnableUpgradeable {
         return exContract.depositBalances(userAddress, tokenAddress);
     }
 
+    /**
+     * @notice Retrieve the amount of a given token staked by a specified 
+     * using a particular platform
+     * @param platformContract Address to the platform where the tokens were
+     * staked
+     * @param tokenAddress Address to the contract for the staked token
+     * @param userAddress Address to the user's wallet
+     * @return The amount of tokens staked by the given user via the 
+     * provided platform contract
+     */
     function getAmountCurrentlyFarmStakedByContract(
         address platformContract,
         address tokenAddress,
@@ -234,6 +349,13 @@ contract PlexusOracle is OwnableUpgradeable {
         return exContract.getStakedPoolBalanceByUser(userAddress, tokenAddress);
     }
 
+   /**
+     * @notice Retrieve the balance of a given token for a specified user
+     * @param userAddress Address to the user's wallet 
+     * @param tokenAddress Address to the token for which the balance is to be 
+     * retrieved
+     * @return Balance of the given token in the specified user wallet
+     */
     function getUserTokenBalance(
         address userAddress, 
         address tokenAddress
@@ -246,6 +368,12 @@ contract PlexusOracle is OwnableUpgradeable {
         return token.balanceOf(userAddress);
     }
 
+    /** 
+     * @notice Allows contract owner to update the contract address for a given 
+     * platform 
+     * @param name String identifier for the platform
+     * @param theAddress New address to the platform contract
+     */
     function updateDirectory(
         string memory name, 
         address theAddress
@@ -258,6 +386,15 @@ contract PlexusOracle is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Retrieve the APR yield for a given token from a specified
+     * yield farm
+     * @param farmAddress Address to the specified yield farm contract
+     * @param farmToken Address to the given token for which the APR
+     * yield is to be retrieved 
+     * @return APR yield for the given token address from the specified yield 
+     * farm
+     */
     function getAPR(address farmAddress, address farmToken) public view returns (uint256) {
         uint256 obtainedAPY = farmManuallyEnteredAPYs[farmAddress][farmToken];
 
@@ -275,10 +412,21 @@ contract PlexusOracle is OwnableUpgradeable {
         }
     }
 
+    /**
+     * @notice Retrieve the given platform component's address
+     * @param component String identifier for the given platform component 
+     * @return Address to the given platform component
+     */
     function getAddress(string memory component) public view returns (address) {
         return platformDirectory[component];
     }
 
+    /** 
+     * @notice Calculate the DAOs commission earnings for a given amount 
+     * @param amount Amount value to compute the commission for
+     * @param commission Current DAO commission rate
+     * @return Commission amount earned by the DAO
+     */
     function calculateCommission(
         uint256 amount, 
         uint256 commission
@@ -291,6 +439,15 @@ contract PlexusOracle is OwnableUpgradeable {
         return commissionForDAO;
     }
 
+    /**
+     * @notice Given an input asset amount and an array of token addresses, 
+     * calculates all subsequent maximum output token amounts for each pair of 
+     * token addresses in the path
+     * @param theAddresses Array of token contract addresses in the path
+     * @param amount Given input asset amount 
+     * @return amounts1 Array containing maximum output token amounts for each
+     * pair of token addresses in the swap path
+     */
     function getUniswapPrice(
         address[] memory theAddresses, 
         uint256 amount

--- a/contracts/WrapAndUnWrap.sol
+++ b/contracts/WrapAndUnWrap.sol
@@ -1,67 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
-                                       `.-:+osyhhhhhhyso+:-.`
-                                   .:+ydmNNNNNNNNNNNNNNNNNNmdy+:.
-                                .+ymNNNNNNNNNNNNNNNNNNNNNNNNNNNNmy+.
-                             `/hmNNNNNNNNmdys+//:::://+sydmNNNNNNNNmh/`
-                           .odNNNNNNNdy+-.`              `.-+ydNNNNNNNdo.
-                         `omNNNNNNdo-`                        `-odNNNNNNmo`
-                        :dNNNNNNh/`                              `/hNNNNNNd:
-                      `oNNNNNNh:                     /-/.           :hNNNNNNo`
-                     `yNNNNNm+`                      mNNm-           `+mNNNNNy`
-                    `hNNNNNd-                        hNNNm.            -dNNNNNh`
-                    yNNNNNd.                         .ymNNh             .dNNNNNy
-                   /NNNNNm.                            -mNNys+.          .mNNNNN/
-                  `mNNNNN:                           `:hNNNNNNNs`         :NNNNNm`
-                  /NNNNNh                          `+dNNNNNNNNNNd.         hNNNNN/
-                  yNNNNN/               .:+syyhhhhhmNNNNNNNNNNNNNm`        /NNNNNy
-                  dNNNNN.            `+dNNNNNNNNNNNNNNNNNNNNNNNmd+         .NNNNNd
-                  mNNNNN`           -dNNNNNNNNNNNNNNNNNNNNNNm-             `NNNNNm
-                  dNNNNN.          -NNNNNNNNNNNNNNNNNNNNNNNN+              .NNNNNd
-                  yNNNNN/          dNNNNNNNNNNNNNNNNNNNNNNNN:              /NNNNNy
-                  /NNNNNh         .NNNNNNNNNNNNNNNNNNNNNNNNd`              hNNNNN/
-                  `mNNNNN:        -NNNNNNNNNNNNNNNNNNNNNNNh.              :NNNNNm`
-                   /NNNNNm.       `NNNNNNNNNNNNNNNNNNNNNh:               .mNNNNN/
-                    yNNNNNd.      .yNNNNNNNNNNNNNNNdmNNN/               .dNNNNNy
-                    `hNNNNNd-    `dmNNNNNNNNNNNNdo-`.hNNh              -dNNNNNh`
-                     `yNNNNNm+`   oNNmmNNNNNNNNNy.   `sNNdo.         `+mNNNNNy`
-                      `oNNNNNNh:   ....++///+++++.     -+++.        :hNNNNNNo`
-                        :dNNNNNNh/`                              `/hNNNNNNd:
-                         `omNNNNNNdo-`                        `-odNNNNNNmo`
-                           .odNNNNNNNdy+-.`              `.-+ydNNNNNNNdo.
-                             `/hmNNNNNNNNmdys+//:::://+sydmNNNNNNNNmh/`
-                                .+ymNNNNNNNNNNNNNNNNNNNNNNNNNNNNmy+.
-                                   .:+ydmNNNNNNNNNNNNNNNNNNmdy+:.
-                                       `.-:+yourewelcome+:-.`
- /$$$$$$$  /$$                                               /$$      /$$
-| $$__  $$| $$                                              | $$$    /$$$
-| $$  \ $$| $$  /$$$$$$  /$$   /$$ /$$   /$$  /$$$$$$$      | $$$$  /$$$$  /$$$$$$  /$$$$$$$   /$$$$$$  /$$   /$$
-| $$$$$$$/| $$ /$$__  $$|  $$ /$$/| $$  | $$ /$$_____/      | $$ $$/$$ $$ /$$__  $$| $$__  $$ /$$__  $$| $$  | $$
-| $$____/ | $$| $$$$$$$$ \  $$$$/ | $$  | $$|  $$$$$$       | $$  $$$| $$| $$  \ $$| $$  \ $$| $$$$$$$$| $$  | $$
-| $$      | $$| $$_____/  >$$  $$ | $$  | $$ \____  $$      | $$\  $ | $$| $$  | $$| $$  | $$| $$_____/| $$  | $$
-| $$      | $$|  $$$$$$$ /$$/\  $$|  $$$$$$/ /$$$$$$$/      | $$ \/  | $$|  $$$$$$/| $$  | $$|  $$$$$$$|  $$$$$$$
-|__/      |__/ \_______/|__/  \__/ \______/ |_______/       |__/     |__/ \______/ |__/  |__/ \_______/ \____  $$
-                                                                                                        /$$  | $$
-                                                                                                       |  $$$$$$/
-                                                                                                       \______/
-
-*/
-
-
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 pragma solidity >=0.8.0 <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -73,14 +10,15 @@ import "./interfaces/token/ILPERC20.sol";
 import "./interfaces/uniswap/IUniswapV2.sol";
 import "./interfaces/uniswap/IUniswapFactory.sol";
 
+/// @title Plexus LP Wrapper Contract
+/// @author Team Plexus
 contract WrapAndUnWrap is OwnableUpgradeable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
-    //  address payable public owner;
-    //placehodler token address for specifying eth tokens
-    address public ETH_TOKEN_ADDRESS;
-    address public WETH_TOKEN_ADDRESS;
+    // Contract state variables
+    address public ETH_TOKEN_ADDRESS; // Contract address for ETH tokens
+    address public WETH_TOKEN_ADDRESS; // Contract address for WETH tokens
     bool public changeRecpientIsOwner;
     address private uniAddress;
     address private uniFactoryAddress;
@@ -98,12 +36,30 @@ contract WrapAndUnWrap is OwnableUpgradeable {
     constructor() payable {
     }
 
+    /**
+     * @notice Executed on a call to the contract if none of the other 
+     * functions match the given function signature, or if no data was 
+     * supplied at all and there is no receive Ether function
+     */
     fallback() external payable {
     }
 
+    /**
+     * @notice Function executed on plain ether transfers and on a call to the 
+     * contract with empty calldata 
+     */
     receive() external payable {
     }
 
+    /**
+     * @notice Initialize the Wrapper contract
+     * @param _weth Address to the WETH token contract
+     * @param _uniAddress Address to the Uniswap V2 router contract
+     * @param _uniFactoryAddress Address to the Uniswap factory contract
+     * @param _dai Address to the DAI token contract
+     * @param _usdt Address to the USDT token contract
+     * @param _usdc Address to the USDC token contract
+     */
     function initialize(
         address _weth, 
         address _uniAddress, 
@@ -132,6 +88,11 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         changeRecpientIsOwner = false;
     }
 
+    /**
+     * @notice Update token contract address for a given stablecoin
+     * @param coinName String identifier to the given stablecoin
+     * @param newAddress Updated contract address for the stablecoin
+     */
     function updateStableCoinAddress(
         string memory coinName, 
         address newAddress
@@ -144,6 +105,13 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Update the preset path to implement a swap between two tokens
+     * @param sellToken Contract address for the token swap's sell token
+     * @param buyToken Contract address for the token swap's buy token 
+     * @param newPath Array representing the updated path between the two 
+     * tokens
+     */
     function updatePresetPaths(
         address sellToken,
         address buyToken,
@@ -157,7 +125,12 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         return true;
     }
 
-    // Owner can turn on ability to collect a small fee from trade imbalances on LP conversions
+    /**
+     * @notice Allow owner to collect a small fee from trade imbalances on 
+     * LP conversions 
+     * @param changeRecpientIsOwnerBool If set to true, allows owner to collect
+     * fees from pair imbalances
+     */
     function updateChangeRecipientBool(
         bool changeRecpientIsOwnerBool
     )
@@ -169,18 +142,33 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Update the Uniswap exchange contract address
+     * @param newAddress Uniswap exchange contract address to be updated
+     */
     function updateUniswapExchange(address newAddress) external onlyOwner returns (bool) {
         uniswapExchange = IUniswapV2(newAddress);
         uniAddress = newAddress;
         return true;
     }
 
+    /**
+     * @notice Update the Uniswap factory contract address
+     * @param newAddress Uniswap factory contract address to be updated
+     */
     function updateUniswapFactory(address newAddress) external onlyOwner returns (bool) {
         factory = IUniswapFactory(newAddress);
         uniFactoryAddress = newAddress;
         return true;
     }
 
+    /**
+    * @notice Allow admins to withdraw accidentally deposited tokens 
+    * @param token Address to the token to be withdrawn 
+    * @param amount Amount of specified token to be withdrawn 
+    * @param destination Address where the withdrawn tokens should be 
+    * transferred
+    */
     function adminEmergencyWithdrawTokens(
         address token,
         uint256 amount,
@@ -199,6 +187,10 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Update the protocol fee rate
+     * @param newFee Updated fee rate to be charged 
+     */
     function setFee(uint256 newFee) public onlyOwner returns (bool) {
         require(
             newFee <= maxfee,
@@ -208,12 +200,22 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Set the max protocol fee rate
+     * @param newMax Updated maximum fee rate value
+     */
     function setMaxFee(uint256 newMax) public onlyOwner returns (bool) {
         require(maxfee == 0, "Admin can only set max fee once and it is perm");
         maxfee = newMax;
         return true;
     }
 
+    /**
+     * @notice Register a LP token with the underlying token pair
+     * @param lpAddress Address to the LP token's contract
+     * @param token1 Address to the LP's first token
+     * @param token2 Address to the LP's second token
+     */
     function addLPPair(
         address lpAddress,
         address token1,
@@ -227,6 +229,17 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Wrap a source token based on the specified 
+     * destination token(s) 
+     * @param sourceToken Address to the source token contract
+     * @param destinationTokens Array describing the token(s) which the source
+     * token will be wrapped into
+     * @param amount Amount of source token to be wrapped
+     * @param userSlippageTolerance Maximum permissible user slippage tolerance
+     * @return Address to the token contract for the destination token and the 
+     * amount of wrapped tokens
+     */
     function wrap(
         address sourceToken,
         address[] memory destinationTokens,
@@ -356,6 +369,15 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         }
     }
 
+    /**
+     * @notice Unwrap a source token based to the specified destination token 
+     * @param sourceToken Address to the source token contract
+     * @param destinationToken Address to the destination token contract
+     * @param amount Amount of source token to be unwrapped
+     * @param userSlippageTolerance Maximum permissible user slippage tolerance
+     * @return Amount of the destination token returned from unwrapping the
+     * source token
+     */
     function unwrap(
         address sourceToken,
         address destinationToken,
@@ -472,6 +494,15 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         }
     }
 
+    /**
+     * @notice Given an input asset amount and an array of token addresses, 
+     * calculates all subsequent maximum output token amounts for each pair of 
+     * token addresses in the path.
+     * @param theAddresses Array of addresses that form the Routing swap path 
+     * @param amount Amount of input asset token
+     * @return amounts1 Array with maximum output token amounts for all token
+     * pairs in the swap path
+     */
     function getPriceFromUniswap(address[] memory theAddresses, uint256 amount)
         public
         view
@@ -489,6 +520,13 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         }
     }
 
+    /**
+     * @notice Retrieve the LP token address for a given pair of tokens
+     * @param token1 Address to the first token in the LP pair
+     * @param token2 Address to the second token in the LP pair
+     * @return lpAddr Address to the LP token contract composed of the given 
+     * token pair 
+     */
     function getLPTokenByPair(
         address token1, 
         address token2
@@ -501,6 +539,13 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         return thisPairAddress;
     }
 
+    /**
+     * @notice Retrieve the balance of a given token for a specified user
+     * @param userAddress Address to the user's wallet 
+     * @param tokenAddress Address to the token for which the balance is to be 
+     * retrieved
+     * @return Balance of the given token in the specified user wallet
+     */
     function getUserTokenBalance(
         address userAddress, 
         address tokenAddress
@@ -513,6 +558,15 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         return token.balanceOf(userAddress);
     }
 
+    /**
+     * @notice Retrieve minimum output amount required based on uniswap routing 
+     * path and maximum permissible slippage
+     * @param theAddresses Array list describing the Uniswap router swap path
+     * @param amount Amount of input tokens to be swapped
+     * @param userSlippageTolerance Maximum permissible user slippage tolerance
+     * @return Minimum amount of output tokens the input token can be swapped
+     * for, based on the Uniswap prices and Slippage tolerance thresholds
+     */
     function getAmountOutMin(
         address[] memory theAddresses, 
         uint256 amount, 
@@ -527,7 +581,15 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         return SafeMath.div(SafeMath.mul(assetAmounts[1], (100 - userSlippageTolerance)), 100);
     }
 
-    // Gets the best path to route the transaction on Uniswap
+    /**
+     * @notice Get the best path to route a swap transaction between two tokens
+     * on Uniswap
+     * @param sellToken Address to the sell token of the swap transaction 
+     * @param buyToken Address to the buy token of the swap transaction
+     * @param amount Amount of selling token which is to be swapped
+     * @return Array of token addresses that represent the most optimal
+     * transaction path for the swap
+     */
     function getBestPath(
         address sellToken,
         address buyToken,
@@ -623,6 +685,15 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         }
     }
 
+    /**
+     * @notice Perform a Uniswap transaction to swap between a given pair of 
+     * tokens of the specified amount 
+     * @param sellToken Address to the token being sold as part of the swap
+     * @param buyToken Address to the token being bought as part of the swap
+     * @param amount Transaction amount denoted in terms of the token sold
+     * @param userSlippageTolerance Maximum permissible slippage limit
+     * @return amounts1 Tokens received once the swap is completed
+     */
     function conductUniswap(
         address sellToken,
         address buyToken,
@@ -673,6 +744,17 @@ contract WrapAndUnWrap is OwnableUpgradeable {
         }
     }
 
+    /**
+     * @notice Using Uniswap, exchange an exact amount of input tokens for as 
+     * many output tokens as possible, along the route determined by the path. 
+     * @param theAddresses Array of addresses representing the path where the 
+     * first address is the input token and the last address is the output 
+     * token
+     * @param amount Amount of input tokens to be swapped
+     * @param userSlippageTolerance Maximum permissible slippage tolerance
+     * @return amounts_ The input token amount and all subsequent output token 
+     * amounts
+     */
     function conductUniswapT4T(
         address[] memory theAddresses, 
         uint256 amount, 

--- a/contracts/WrapAndUnWrapSushi.sol
+++ b/contracts/WrapAndUnWrapSushi.sol
@@ -1,65 +1,4 @@
 // SPDX-License-Identifier: MIT
-
-/*
-                                       `.-:+osyhhhhhhyso+:-.`
-                                   .:+ydmNNNNNNNNNNNNNNNNNNmdy+:.
-                                .+ymNNNNNNNNNNNNNNNNNNNNNNNNNNNNmy+.
-                             `/hmNNNNNNNNmdys+//:::://+sydmNNNNNNNNmh/`
-                           .odNNNNNNNdy+-.`              `.-+ydNNNNNNNdo.
-                         `omNNNNNNdo-`                        `-odNNNNNNmo`
-                        :dNNNNNNh/`                              `/hNNNNNNd:
-                      `oNNNNNNh:                     /-/.           :hNNNNNNo`
-                     `yNNNNNm+`                      mNNm-           `+mNNNNNy`
-                    `hNNNNNd-                        hNNNm.            -dNNNNNh`
-                    yNNNNNd.                         .ymNNh             .dNNNNNy
-                   /NNNNNm.                            -mNNys+.          .mNNNNN/
-                  `mNNNNN:                           `:hNNNNNNNs`         :NNNNNm`
-                  /NNNNNh                          `+dNNNNNNNNNNd.         hNNNNN/
-                  yNNNNN/               .:+syyhhhhhmNNNNNNNNNNNNNm`        /NNNNNy
-                  dNNNNN.            `+dNNNNNNNNNNNNNNNNNNNNNNNmd+         .NNNNNd
-                  mNNNNN`           -dNNNNNNNNNNNNNNNNNNNNNNm-             `NNNNNm
-                  dNNNNN.          -NNNNNNNNNNNNNNNNNNNNNNNN+              .NNNNNd
-                  yNNNNN/          dNNNNNNNNNNNNNNNNNNNNNNNN:              /NNNNNy
-                  /NNNNNh         .NNNNNNNNNNNNNNNNNNNNNNNNd`              hNNNNN/
-                  `mNNNNN:        -NNNNNNNNNNNNNNNNNNNNNNNh.              :NNNNNm`
-                   /NNNNNm.       `NNNNNNNNNNNNNNNNNNNNNh:               .mNNNNN/
-                    yNNNNNd.      .yNNNNNNNNNNNNNNNdmNNN/               .dNNNNNy
-                    `hNNNNNd-    `dmNNNNNNNNNNNNdo-`.hNNh              -dNNNNNh`
-                     `yNNNNNm+`   oNNmmNNNNNNNNNy.   `sNNdo.         `+mNNNNNy`
-                      `oNNNNNNh:   ....++///+++++.     -+++.        :hNNNNNNo`
-                        :dNNNNNNh/`                              `/hNNNNNNd:
-                         `omNNNNNNdo-`                        `-odNNNNNNmo`
-                           .odNNNNNNNdy+-.`              `.-+ydNNNNNNNdo.
-                             `/hmNNNNNNNNmdys+//:::://+sydmNNNNNNNNmh/`
-                                .+ymNNNNNNNNNNNNNNNNNNNNNNNNNNNNmy+.
-                                   .:+ydmNNNNNNNNNNNNNNNNNNmdy+:.
-                                       `.-:+yourewelcome+:-.`
- /$$$$$$$  /$$                                               /$$      /$$
-| $$__  $$| $$                                              | $$$    /$$$
-| $$  \ $$| $$  /$$$$$$  /$$   /$$ /$$   /$$  /$$$$$$$      | $$$$  /$$$$  /$$$$$$  /$$$$$$$   /$$$$$$  /$$   /$$
-| $$$$$$$/| $$ /$$__  $$|  $$ /$$/| $$  | $$ /$$_____/      | $$ $$/$$ $$ /$$__  $$| $$__  $$ /$$__  $$| $$  | $$
-| $$____/ | $$| $$$$$$$$ \  $$$$/ | $$  | $$|  $$$$$$       | $$  $$$| $$| $$  \ $$| $$  \ $$| $$$$$$$$| $$  | $$
-| $$      | $$| $$_____/  >$$  $$ | $$  | $$ \____  $$      | $$\  $ | $$| $$  | $$| $$  | $$| $$_____/| $$  | $$
-| $$      | $$|  $$$$$$$ /$$/\  $$|  $$$$$$/ /$$$$$$$/      | $$ \/  | $$|  $$$$$$/| $$  | $$|  $$$$$$$|  $$$$$$$
-|__/      |__/ \_______/|__/  \__/ \______/ |_______/       |__/     |__/ \______/ |__/  |__/ \_______/ \____  $$
-                                                                                                        /$$  | $$
-                                                                                                       |  $$$$$$/
-                                                                                                       \______/
-*/
-
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 pragma solidity >=0.8.0 <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -71,13 +10,15 @@ import "./interfaces/token/ILPERC20.sol";
 import "./interfaces/sushiswap/ISushiV2.sol";
 import "./interfaces/uniswap/IUniswapFactory.sol";
 
+/// @title Plexus LP Wrapper Contract - SushiSwap
+/// @author Team Plexus
 contract WrapAndUnWrapSushi is OwnableUpgradeable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
 
-    //placehodler token address for specifying eth tokens
-    address public ETH_TOKEN_ADDRESS;
-    address public WETH_TOKEN_ADDRESS;
+    // Contract state variables
+    address public ETH_TOKEN_ADDRESS; // Contract address for ETH tokens
+    address public WETH_TOKEN_ADDRESS; // Contract address for WETH tokens
     bool public changeRecpientIsOwner;
     address private sushiAddress;
     address private uniFactoryAddress;
@@ -94,6 +35,15 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
 
     constructor() payable {}
 
+    /**
+     * @notice Initialize the Sushi Wrapper contract
+     * @param _weth Address to the WETH token contract
+     * @param _sushiAddress Address to the SushiSwap contract
+     * @param _uniFactoryAddress Address to the Uniswap factory contract
+     * @param _dai Address to the DAI token contract
+     * @param _usdt Address to the USDT token contract
+     * @param _usdc Address to the USDC token contract
+     */
     function initialize(
         address _weth,
         address _sushiAddress,
@@ -122,15 +72,34 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         changeRecpientIsOwner = false;
     }
 
+    /**
+     * @notice Modifier check to ensure that a function is executed only if it 
+     * was called with a non-zero amount value 
+     * @param amount Amount value 
+     */
     modifier nonZeroAmount(uint256 amount) {
         require(amount > 0, "Amount specified is zero");
         _;
     }
 
+    /**
+     * @notice Executed on a call to the contract if none of the other 
+     * functions match the given function signature, or if no data was 
+     * supplied at all and there is no receive Ether function
+     */
     fallback() external payable {}
 
+     /**
+     * @notice Function executed on plain ether transfers and on a call to the 
+     * contract with empty calldata 
+     */
     receive() external payable {}
 
+    /**
+     * @notice Update token contract address for a given stablecoin
+     * @param coinName String identifier to the given stablecoin
+     * @param newAddress Updated contract address for the stablecoin
+     */
     function updateStableCoinAddress(string memory coinName, address newAddress)
         external
         onlyOwner
@@ -140,6 +109,13 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Update the preset path to implement a swap between two tokens
+     * @param sellToken Contract address for the token swap's sell token
+     * @param buyToken Contract address for the token swap's buy token 
+     * @param newPath Array representing the updated path between the two 
+     * tokens
+     */
     function updatePresetPaths(
         address sellToken,
         address buyToken,
@@ -153,7 +129,12 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         return true;
     }
 
-    // Owner can turn on ability to collect a small fee from trade imbalances on LP conversions
+    /**
+     * @notice Allow owner to collect a small fee from trade imbalances on 
+     * LP conversions 
+     * @param changeRecpientIsOwnerBool If set to true, allows owner to collect
+     * fees from pair imbalances
+     */
     function updateChangeRecipientBool(bool changeRecpientIsOwnerBool)
         external
         onlyOwner
@@ -163,6 +144,10 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Update the SushiSwap exchange contract address
+     * @param newAddress SushiSwap exchange contract address to be updated
+     */
     function updateSushiExchange(address newAddress)
         external
         onlyOwner
@@ -173,6 +158,10 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         return true;
     }
 
+     /**
+     * @notice Update the Uniswap factory contract address
+     * @param newAddress Uniswap factory contract address to be updated
+     */
     function updateUniswapFactory(address newAddress)
         external
         onlyOwner
@@ -183,6 +172,12 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Register a LP token with the underlying token pair
+     * @param lpAddress Address to the LP token's contract
+     * @param token1 Address to the LP's first token
+     * @param token2 Address to the LP's second token
+     */
     function addLPPair(
         address lpAddress,
         address token1,
@@ -196,6 +191,13 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Retrieve the LP token address for a given pair of tokens
+     * @param token1 Address to the first token in the LP pair
+     * @param token2 Address to the second token in the LP pair
+     * @return lpAddr Address to the LP token contract composed of the given 
+     * token pair 
+     */
     function getLPTokenByPair(
         address token1, 
         address token2
@@ -208,6 +210,13 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         return thisPairAddress;
     }
 
+    /**
+     * @notice Retrieve the balance of a given token for a specified user
+     * @param userAddress Address to the user's wallet 
+     * @param tokenAddress Address to the token for which the balance is to be 
+     * retrieved
+     * @return Balance of the given token in the specified user wallet
+     */
     function getUserTokenBalance(
         address userAddress, 
         address tokenAddress
@@ -220,6 +229,13 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         return token.balanceOf(userAddress);
     }
 
+    /**
+    * @notice Allow admins to withdraw accidentally deposited tokens 
+    * @param token Address to the token to be withdrawn 
+    * @param amount Amount of specified token to be withdrawn 
+    * @param destination Address where the withdrawn tokens should be 
+    * transferred
+    */
     function adminEmergencyWithdrawTokens(
         address token,
         uint256 amount,
@@ -238,6 +254,10 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         return true;
     }
 
+    /**
+     * @notice Update the protocol fee rate
+     * @param newFee Updated fee rate to be charged 
+     */
     function setFee(uint256 newFee) public onlyOwner returns (bool) {
         require(
             newFee <= maxfee,
@@ -247,12 +267,27 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         return true;
     }
 
+     /**
+     * @notice Set the max protocol fee rate
+     * @param newMax Updated maximum fee rate value
+     */
     function setMaxFee(uint256 newMax) public onlyOwner returns (bool) {
         require(maxfee == 0, "Admin can only set max fee once and it is perm");
         maxfee = newMax;
         return true;
     }
 
+    /**
+     * @notice Wrap a source token based on the specified 
+     * destination token(s) 
+     * @param sourceToken Address to the source token contract
+     * @param destinationTokens Array describing the token(s) which the source
+     * token will be wrapped into
+     * @param amount Amount of source token to be wrapped
+     * @param userSlippageTolerance Maximum permissible user slippage tolerance
+     * @return Address to the token contract for the destination token and the 
+     * amount of wrapped tokens
+     */
     function wrap(
         address sourceToken,
         address[] memory destinationTokens,
@@ -417,6 +452,15 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         }
     }
 
+    /**
+     * @notice Unwrap a source token based to the specified destination token 
+     * @param sourceToken Address to the source token contract
+     * @param destinationToken Address to the destination token contract
+     * @param amount Amount of source token to be unwrapped
+     * @param userSlippageTolerance Maximum permissible user slippage tolerance
+     * @return Amount of the destination token returned from unwrapping the
+     * source token
+     */
     function unwrap(
         address sourceToken,
         address destinationToken,
@@ -550,7 +594,15 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         }
     }
 
-    // Gets the best path to route the transaction on Uniswap
+    /**
+     * @notice Get the best path to route a swap transaction between two tokens
+     * on SushiSwap
+     * @param sellToken Address to the sell token of the swap transaction 
+     * @param buyToken Address to the buy token of the swap transaction
+     * @param amount Amount of selling token which is to be swapped
+     * @return Array of token addresses that represent the most optimal
+     * transaction path for the swap
+     */
     function getBestPath(
         address sellToken,
         address buyToken,
@@ -661,6 +713,15 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         }
     }
 
+    /**
+     * @notice Given an input asset amount and an array of token addresses, 
+     * calculates all subsequent maximum output token amounts for each pair of 
+     * token addresses in the path using SushiSwap
+     * @param theAddresses Array of addresses that form the Routing swap path 
+     * @param amount Amount of input asset token
+     * @return amounts1 Array with maximum output token amounts for all token
+     * pairs in the swap path
+     */
     function getPriceFromSushiswap(
         address[] memory theAddresses,
         uint256 amount
@@ -681,6 +742,15 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         }
     }
 
+    /**
+     * @notice Retrieve minimum output amount required based on uniswap routing 
+     * path and maximum permissible slippage
+     * @param theAddresses Array list describing the SushiSwap swap path
+     * @param amount Amount of input tokens to be swapped
+     * @param userSlippageTolerance Maximum permissible user slippage tolerance
+     * @return Minimum amount of output tokens the input token can be swapped
+     * for, based on the Uniswap prices and Slippage tolerance thresholds
+     */
     function getAmountOutMin(
         address[] memory theAddresses,
         uint256 amount,
@@ -705,6 +775,15 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
             );
     }
 
+     /**
+     * @notice Perform a SushiSwap transaction to swap between a given pair of 
+     * tokens of the specified amount 
+     * @param sellToken Address to the token being sold as part of the swap
+     * @param buyToken Address to the token being bought as part of the swap
+     * @param amount Transaction amount denoted in terms of the token sold
+     * @param userSlippageTolerance Maximum permissible slippage limit
+     * @return amounts1 Tokens received once the swap is completed
+     */
     function conductUniswap(
         address sellToken,
         address buyToken,
@@ -776,6 +855,17 @@ contract WrapAndUnWrapSushi is OwnableUpgradeable {
         }
     }
 
+    /**
+     * @notice Using SushiSwap, exchange an exact amount of input tokens for as 
+     * many output tokens as possible, along the route determined by the path. 
+     * @param theAddresses Array of addresses representing the path where the 
+     * first address is the input token and the last address is the output 
+     * token
+     * @param amount Amount of input tokens to be swapped
+     * @param userSlippageTolerance Maximum permissible slippage tolerance
+     * @return amounts1 The input token amount and all subsequent output token 
+     * amounts
+     */
     function conductUniswapT4T(
         address[] memory theAddresses,
         uint256 amount,

--- a/contracts/core.sol
+++ b/contracts/core.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-
 pragma solidity >=0.8.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
@@ -12,12 +11,13 @@ import "./interfaces/staking/ITier1Staking.sol";
 import "./interfaces/IConverter.sol";
 import "./interfaces/token/IWETH.sol";
 
-// Core contract on Mainnet: 0x7a72b2C51670a3D77d4205C2DB90F6ddb09E4303
-
+/// @title Plexus Core Contract
+/// @author Team Plexus
+/// @notice Mainnet address - 0x7a72b2C51670a3D77d425C2DB90F6ddb09E4303
 contract Core is OwnableUpgradeable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
-    // globals
+    // Global state variables
     address public oracleAddress;
     address public converterAddress;
     address public stakingAddress;
@@ -32,21 +32,37 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
     constructor() payable {
     }
 
-    fallback() external payable {
-        // For the converter to unwrap ETH when delegate calling.
-        // The contract has to be able to accept ETH for this reason.
-        // The emergency withdrawal call is to pick any change up for these conversions.
-    }
+    /**
+     * @notice Executed on a call to the contract if none of the other 
+     * functions match the given function signature, or if no data was 
+     * supplied at all and there is no receive Ether function
+     * @dev For the converter to unwrap ETH when delegate calling. The 
+     * contract has to be able to accept ETH for this reason. The emergency 
+     * withdrawal call is to pick any change up for these conversions 
+     */
+    fallback() external payable { }
 
-    receive() external payable {
-        // receive function
-    }
+    /**
+     * @notice Function executed on plain ether transfers and on a call to the 
+     * contract with empty calldata 
+     */
+    receive() external payable { }
 
+    /**
+     * @notice Modifier check to ensure that a function is executed only if it 
+     * was called with a non-zero amount value 
+     * @param amount Amount value 
+     */
     modifier nonZeroAmount(uint256 amount) {
         require(amount > 0, "Amount specified is zero");
         _;
     }
 
+    /**
+     * @notice Initialize the core contract 
+     * @param _weth Address to the WETH token contract 
+     * @param _converter Address to the converter contract 
+     */
     function initialize(address _weth, address _converter) external initializeOnceOnly {
         ETH_TOKEN_ADDRESS = address(0x0);
         WETH_TOKEN_ADDRESS = _weth;
@@ -55,18 +71,32 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         setConverterAddress(_converter);
     }
 
+    /**
+     * @notice Set the oracle contract address
+     * @param theAddress Oracle contract address 
+     */
     function setOracleAddress(address theAddress) external onlyOwner returns (bool) {
         oracleAddress = theAddress;
         oracle = IPlexusOracle(theAddress);
         return true;
     }
 
+    /**
+     * @notice Set the Tier1 staking contract address
+     * @param theAddress Tier 1 staking contract address 
+     */
     function setStakingAddress(address theAddress) external onlyOwner returns (bool) {
         stakingAddress = theAddress;
         staking = ITier1Staking(theAddress);
         return true;
     }
 
+    /**
+     * @notice Deposit assets via a given Tier 2 staking contract
+     * @param tier2ContractName Tier 2 contract used to deposit assets
+     * @param tokenAddress Token address for the asset to be withdrawn
+     * @param amount Quantity of specified token to be deposited
+     */
     function deposit(
         string memory tier2ContractName,
         address tokenAddress,
@@ -94,6 +124,12 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return result;
     }
 
+    /**
+     * @notice Withdraw assets from a given Tier 2 staking contract
+     * @param tier2ContractName Tier 2 contract used to withdraw assets
+     * @param tokenAddress Token address for the asset to be withdrawn
+     * @param amount Quantity of specified token to be withdrawn
+     */
     function withdraw(
         string memory tier2ContractName,
         address tokenAddress,
@@ -110,6 +146,16 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return result;
     }
 
+    /**
+     * @notice Convert a provided source token to multiple output tokens
+     * @dev Converting is mostly for removing liquidity from LP tokens by  
+     * swapping them for their underlying assets
+     * @param sourceToken Address to provided source LP tokens
+     * @param destinationTokens Address list for output destination tokens
+     * @param amount Amount of provided LP tokens to be converted
+     * @param userSlippageTolerance Maximum slippage tolerance limit
+     * @return Output tokens acquired by swapping provided source tokens
+     */
     function convert(
         address sourceToken,
         address[] memory destinationTokens,
@@ -138,8 +184,16 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return (destinationTokenAddress, _amount);
     }
 
-    // deconverting is mostly for LP tokens back to another token, 
-    // as these cant be simply swapped on uniswap
+    /**
+     * @notice Convert provided LP tokens to a common output token
+     * @dev De-converting is mostly for LP tokens back to another token, as  
+     * these cant be simply swapped on uniswap
+     * @param sourceToken Address to provided source LP tokens
+     * @param destinationToken Address to desired output destination tokens
+     * @param amount Amount of provided LP tokens to be converted
+     * @param userSlippageTolerance Maximum slippage tolerance limit
+     * @return Destination tokens acquired by converting provided LP tokens
+     */
     function deconvert(
         address sourceToken,
         address destinationToken,
@@ -164,6 +218,11 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return _amount;
     }
 
+    /**
+     * @notice Retrieve details about all tokens that can be staked 
+     * @return Two arrays - one containing a list of addresses to all tokens 
+     * that can be staked and another containing their respective token names 
+     */
     function getStakableTokens() external view returns (address[] memory, string[] memory) {
         (
             address[] memory stakableAddresses, 
@@ -172,6 +231,15 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return (stakableAddresses, stakableTokenNames);
     }
 
+    /**
+     * @notice Retrieve the APR yield for a given token from a specified
+     * Tier 2 contract
+     * @param tier2Address Address to the specified Tier 2 contract
+     * @param tokenAddress Address to the given token for which the APR
+     * yield is to be retrieved 
+     * @return APR yield for the given token address from the specified Tier 2 
+     * contract
+     */
     function getAPR(address tier2Address, address tokenAddress) external view returns (uint256) {
         uint256 result = oracle.getAPR(tier2Address, tokenAddress);
         return result;
@@ -182,6 +250,15 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return result;
     }
 
+    /**
+     * @notice Retrieve the TVL for a given token from the specified Tier 2
+     * contract
+     * @param tokenAddress Address to the given token for which the TVL is to 
+     * be retrieved 
+     * @param tier2Address Address to the Tier 2 contract to retrieve the TVL
+     * from
+     * @return TVL for the given token from the specified Tier 2 contract
+     */
     function getTotalValueLockedInternalByToken(
         address tokenAddress,
         address tier2Address
@@ -190,6 +267,17 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return result;
     }
 
+    /**
+     * @notice Retrieve the amount of a given token staked by a particular user
+     * using a specified Tier 2 contract
+     * @param tokenAddress Address to the given token for which the staked 
+     * amount is to be retrieved
+     * @param userAddress Address to the user's wallet
+     * @param tier2Address Address to the Tier 2 contract used to stake the 
+     * specified tokens 
+     * @return Amount of specified tokens staked by the given user via the
+     * provided Tier 2 contract
+     */
     function getAmountStakedByUser(
         address tokenAddress,
         address userAddress,
@@ -199,6 +287,17 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return result;
     }
 
+    /**
+     * @notice Retrieve the rewards accumulated by a given user for a specified 
+     * token deposited in a particular Tier 2 contract 
+     * @param userAddress Address to the user's wallet
+     * @param tokenAddress Address to the token for which reward value is to be
+     * retrieved 
+     * @param tier2FarmAddress Address to the Tier 2 contract where the given 
+     * token was deposited
+     * @return Rewards accumulated by the given user for the particular token 
+     * from the specified Tier 2 contract address 
+     */
     function getUserCurrentReward(
         address userAddress,
         address tokenAddress,
@@ -207,11 +306,25 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return oracle.getUserCurrentReward( userAddress, tokenAddress, tier2FarmAddress);
     }
 
+    /** 
+     * @notice Retrieve the current price of a token
+     * @param tokenAddress Address to the token for which the price is to be 
+     * retrieved
+     * @return Current price of the specified token 
+     */
     function getTokenPrice(address tokenAddress) external view returns (uint256) {
         uint256 result = oracle.getTokenPrice(tokenAddress);
         return result;
     }
 
+    /**
+     * @notice Retrieve the balance of a given token from a specified user
+     * wallet 
+     * @param userAddress Address to the user's wallet 
+     * @param tokenAddress Address to the token for which the balance is to be 
+     * retrieved
+     * @return Balance of the given token in the specified user wallet
+     */
     function getUserWalletBalance(
         address userAddress, 
         address tokenAddress
@@ -224,12 +337,23 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return result;
     }
 
+    /**
+     * @notice Update the WETH token contract address
+     * @param newAddress New WETH contract address to be updated
+     */
     function updateWETHAddress(address newAddress) external onlyOwner returns (bool) {
         WETH_TOKEN_ADDRESS = newAddress;
         wethToken = IWETH(newAddress);
         return true;
     }
 
+    /**
+    * @notice Function allowing admins to revert accidentally deposited tokens 
+    * @param token Address to the token to be withdrawn 
+    * @param amount Amount of specified token to be withdrawn 
+    * @param destination Address where the withdrawn tokens should be 
+    * transferred
+    */
     function adminEmergencyWithdrawAccidentallyDepositedTokens(
         address token,
         uint256 amount,
@@ -245,10 +369,13 @@ contract Core is OwnableUpgradeable, ReentrancyGuard {
         return true;
     }
 
+    /**
+     * @notice Set converter contract address
+     * @param theAddress Converter contract address 
+     */
     function setConverterAddress(address theAddress) public onlyOwner returns (bool) {
         converterAddress = theAddress;
         converter = IConverter(theAddress);
         return true;
     }
 }
-


### PR DESCRIPTION
Add Natspec comments to the Wrappers (Uniswap & Sushiswap), Oracle and Core contract which can be used to render granular documentation for the Plexus contracts